### PR TITLE
Minor correction.

### DIFF
--- a/source/trader/matching/market_manager.cpp
+++ b/source/trader/matching/market_manager.cpp
@@ -1235,7 +1235,7 @@ void MarketManager::MatchOrder(OrderBook* order_book_ptr, Order* order_ptr)
             ReduceOrder(executing_order_ptr->Id, quantity, true);
 
             // Call the corresponding handler
-            _market_handler.onExecuteOrder(*order_ptr, price, quantity);
+            //_market_handler.onExecuteOrder(*order_ptr, price, quantity);
 
             // Update the corresponding market price
             order_book_ptr->UpdateLastPrice(*order_ptr, price);


### PR DESCRIPTION
I think the second "_market_handler.onExecuteOrder(*order_ptr, price, quantity);" (line 1238) is redundant. The market handler will process the execution price and quantity in the first call to "_market_handler.onExecuteOrder(*executing_order_ptr, price, quantity);" (line 1226).