### PR TITLE
Add support for LULD Auction Collar message.

### DIFF
--- a/examples/itch_handler.cpp
+++ b/examples/itch_handler.cpp
@@ -37,6 +37,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { return OutputMessage(message); }
     bool onMessage(const NOIIMessage& message) override { return OutputMessage(message); }
     bool onMessage(const RPIIMessage& message) override { return OutputMessage(message); }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { return OutputMessage(message); }
     bool onMessage(const UnknownMessage& message) override { return OutputMessage(message); }
 
 private:

--- a/include/trader/providers/nasdaq/itch_handler.h
+++ b/include/trader/providers/nasdaq/itch_handler.h
@@ -331,7 +331,7 @@ struct NOIIMessage
     friend TOutputStream& operator<<(TOutputStream& stream, const NOIIMessage& message);
 };
 
-//! Retail Price Improvement Indicator (RPII) Messsage
+//! Retail Price Improvement Indicator (RPII) Message
 struct RPIIMessage
 {
     char Type;
@@ -343,6 +343,23 @@ struct RPIIMessage
 
     template <class TOutputStream>
     friend TOutputStream& operator<<(TOutputStream& stream, const RPIIMessage& message);
+};
+
+//! Limit Up – Limit Down (LULD) Auction Collar Message
+struct LULDAuctionCollarMessage
+{
+    char Type;
+    uint16_t StockLocate;
+    uint16_t TrackingNumber;
+    uint64_t Timestamp;
+    char Stock[8];
+    uint32_t AuctionCollarReferencePrice;
+    uint32_t UpperAuctionCollarPrice;
+    uint32_t LowerAuctionCollarPrice;
+    uint32_t AuctionCollarExtension;
+
+    template <class TOutputStream>
+    friend TOutputStream& operator<<(TOutputStream& stream, const LULDAuctionCollarMessage& message);
 };
 
 //! Unknown message
@@ -418,6 +435,7 @@ protected:
     virtual bool onMessage(const BrokenTradeMessage& message) { return true; }
     virtual bool onMessage(const NOIIMessage& message) { return true; }
     virtual bool onMessage(const RPIIMessage& message) { return true; }
+    virtual bool onMessage(const LULDAuctionCollarMessage& message) { return true; }
     virtual bool onMessage(const UnknownMessage& message) { return true; }
 
 private:
@@ -444,6 +462,7 @@ private:
     bool ProcessBrokenTradeMessage(void* buffer, size_t size);
     bool ProcessNOIIMessage(void* buffer, size_t size);
     bool ProcessRPIIMessage(void* buffer, size_t size);
+    bool ProcessLULDAuctionCollarMessage(void* buffer, size_t size);
     bool ProcessUnknownMessage(void* buffer, size_t size);
 
     template <size_t N>

--- a/include/trader/providers/nasdaq/itch_handler.inl
+++ b/include/trader/providers/nasdaq/itch_handler.inl
@@ -313,6 +313,22 @@ inline TOutputStream& operator<<(TOutputStream& stream, const RPIIMessage& messa
 }
 
 template <class TOutputStream>
+inline TOutputStream& operator<<(TOutputStream& stream, const LULDAuctionCollarMessage& message)
+{
+    stream << "LULDAuctionCollarMessage(Type=" << CppCommon::WriteChar(message.Type)
+        << "; StockLocate=" << message.StockLocate
+        << "; TrackingNumber=" << message.TrackingNumber
+        << "; Timestamp=" << message.Timestamp
+        << "; Stock=" << CppCommon::WriteString(message.Stock)
+        << "; AuctionCollarReferencePrice=" << message.AuctionCollarReferencePrice
+        << "; UpperAuctionCollarPrice=" << message.UpperAuctionCollarPrice
+        << "; LowerAuctionCollarPrice=" << message.LowerAuctionCollarPrice
+        << "; AuctionCollarExtension=" << message.AuctionCollarExtension
+        << ")";
+    return stream;
+}
+
+template <class TOutputStream>
 inline TOutputStream& operator<<(TOutputStream& stream, const UnknownMessage& message)
 {
     stream << "UnknownMessage(Type=" << CppCommon::WriteChar(message.Type) << ")";

--- a/performance/itch_handler.cpp
+++ b/performance/itch_handler.cpp
@@ -46,6 +46,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { ++_messages; return true; }
     bool onMessage(const NOIIMessage& message) override { ++_messages; return true; }
     bool onMessage(const RPIIMessage& message) override { ++_messages; return true; }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { ++_messages; return true; }
     bool onMessage(const UnknownMessage& message) override { ++_errors; return true; }
 
 private:

--- a/performance/market_manager.cpp
+++ b/performance/market_manager.cpp
@@ -109,6 +109,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { ++_messages; return true; }
     bool onMessage(const NOIIMessage& message) override { ++_messages; return true; }
     bool onMessage(const RPIIMessage& message) override { ++_messages; return true; }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { ++_messages; return true; }
     bool onMessage(const UnknownMessage& message) override { ++_errors; return true; }
 
 private:

--- a/performance/market_manager_optimized.cpp
+++ b/performance/market_manager_optimized.cpp
@@ -696,6 +696,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { ++_messages; return true; }
     bool onMessage(const NOIIMessage& message) override { ++_messages; return true; }
     bool onMessage(const RPIIMessage& message) override { ++_messages; return true; }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { ++_messages; return true; }
     bool onMessage(const UnknownMessage& message) override { ++_errors; return true; }
 
 private:

--- a/performance/market_manager_optimized_aggressive.cpp
+++ b/performance/market_manager_optimized_aggressive.cpp
@@ -393,6 +393,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { ++_messages; return true; }
     bool onMessage(const NOIIMessage& message) override { ++_messages; return true; }
     bool onMessage(const RPIIMessage& message) override { ++_messages; return true; }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { ++_messages; return true; }
     bool onMessage(const UnknownMessage& message) override { ++_errors; return true; }
 
 private:

--- a/performance/matching_engine.cpp
+++ b/performance/matching_engine.cpp
@@ -109,6 +109,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { ++_messages; return true; }
     bool onMessage(const NOIIMessage& message) override { ++_messages; return true; }
     bool onMessage(const RPIIMessage& message) override { ++_messages; return true; }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { ++_messages; return true; }
     bool onMessage(const UnknownMessage& message) override { ++_errors; return true; }
 
 private:

--- a/source/trader/providers/nasdaq/itch_handler.cpp
+++ b/source/trader/providers/nasdaq/itch_handler.cpp
@@ -149,6 +149,8 @@ bool ITCHHandler::ProcessMessage(void* buffer, size_t size)
             return ProcessNOIIMessage(data, size);
         case 'N':
             return ProcessRPIIMessage(data, size);
+        case 'J':
+            return ProcessLULDAuctionCollarMessage(data, size);
         default:
             return ProcessUnknownMessage(data, size);
     }
@@ -579,6 +581,28 @@ bool ITCHHandler::ProcessRPIIMessage(void* buffer, size_t size)
     data += ReadTimestamp(data, message.Timestamp);
     data += ReadString(data, message.Stock);
     message.InterestFlag = *data++;
+
+    return onMessage(message);
+}
+
+bool ITCHHandler::ProcessLULDAuctionCollarMessage(void* buffer, size_t size)
+{
+    assert((size == 35) && "Invalid size of the ITCH message type 'J'");
+    if (size != 35)
+        return false;
+
+    uint8_t* data = (uint8_t*)buffer;
+
+    LULDAuctionCollarMessage message;
+    message.Type = *data++;
+    data += CppCommon::Endian::ReadBigEndian(data, message.StockLocate);
+    data += CppCommon::Endian::ReadBigEndian(data, message.TrackingNumber);
+    data += ReadTimestamp(data, message.Timestamp);
+    data += ReadString(data, message.Stock);
+    data += CppCommon::Endian::ReadBigEndian(data, message.AuctionCollarReferencePrice);
+    data += CppCommon::Endian::ReadBigEndian(data, message.UpperAuctionCollarPrice);
+    data += CppCommon::Endian::ReadBigEndian(data, message.LowerAuctionCollarPrice);
+    data += CppCommon::Endian::ReadBigEndian(data, message.AuctionCollarExtension);
 
     return onMessage(message);
 }

--- a/tests/test_itch_handler.cpp
+++ b/tests/test_itch_handler.cpp
@@ -45,6 +45,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { ++_messages; return true; }
     bool onMessage(const NOIIMessage& message) override { ++_messages; return true; }
     bool onMessage(const RPIIMessage& message) override { ++_messages; return true; }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { ++_messages; return true; }
     bool onMessage(const UnknownMessage& message) override { ++_errors; return true; }
 
 private:

--- a/tests/test_market_manager.cpp
+++ b/tests/test_market_manager.cpp
@@ -110,6 +110,7 @@ protected:
     bool onMessage(const BrokenTradeMessage& message) override { ++_messages; return true; }
     bool onMessage(const NOIIMessage& message) override { ++_messages; return true; }
     bool onMessage(const RPIIMessage& message) override { ++_messages; return true; }
+    bool onMessage(const LULDAuctionCollarMessage& message) override { ++_messages; return true; }
     bool onMessage(const UnknownMessage& message) override { ++_errors; return true; }
 
 private:


### PR DESCRIPTION
This is a great project to study high performance trading!

When trying this platform with some recent data feed (e.g., 07302019.NASDAQ_ITCH50), it reports unknown messages contributing to `Errors` count, which is annoying. It turns out to be LULD Auction Collar message introduced to Nasdaq's market data feed specification in late 2017.

This patch adds support to handle such message.